### PR TITLE
Add custom settings by zone

### DIFF
--- a/app/Console/Commands/ProBINDPushZones.php
+++ b/app/Console/Commands/ProBINDPushZones.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Server;
+use App\Zone;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Registry;
+use Storage;
+use Symfony\Component\Process\Process;
+
+class ProBINDPushZones extends Command
+{
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'probind:push';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Generate and push zone files to DNS servers';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $zonesToUpdate = Zone::where('updated', 1)
+            ->orderBy('domain')
+            ->get();
+
+        if ($zonesToUpdate->isEmpty()) {
+            $this->error('Nothing to do');
+
+            return 1;
+        }
+
+        $this->info('Generating Zone Files...');
+
+        $this->generateZoneFiles($zonesToUpdate);
+
+        $servers = Server::where('push_updates', 1)
+            ->orderBy('hostname')
+            ->get();
+
+        foreach ($servers as $server) {
+            // Send updates via BASH file
+            $command = storage_path('app/scripts/push.bash') . ' --server=' . $server->hostname;
+
+            $this->info(sprintf("Sending updates to server '%s' using '%s'", $server->hostname, $command));
+
+            $process = new Process($command);
+            $process->start();
+        }
+    }
+
+    public function generateZoneFiles($zonesToUpdate)
+    {
+        $defaults = Registry::all();
+
+        $nameServers = Server::where('ns_record', 1)
+            ->orderBy('type')
+            ->get();
+
+        Storage::deleteDirectory('probind/');
+
+        foreach ($zonesToUpdate as $zone) {
+
+            $zone->setSerialNumber();
+
+            $records = $zone->records()
+                ->orderBy('name')
+                ->get();
+
+            $contents = view('templates.zone')
+                ->with('servers', $nameServers)
+                ->with('defaults', $defaults)
+                ->with('zone', $zone)
+                ->with('records', $records);
+
+            Storage::put('probind/' . $zone->domain, $contents, 'private');
+
+            $header = sprintf(";\n; This file has been automatically generated using ProBIND v3 on %s.\n;",
+                Carbon::now());
+            Storage::prepend('probind/' . $zone->domain, $header);
+
+            //$zone->setPendingChanges(false);
+        }
+    }
+}

--- a/app/Http/Controllers/RecordController.php
+++ b/app/Http/Controllers/RecordController.php
@@ -47,11 +47,6 @@ class RecordController extends Controller
     {
         $record = new Record();
 
-        // If user doesn't supply a TTL we must use default's one
-        $record->ttl = ($request->input('ttl') == '')
-            ? \Registry::get('record_ttl_default')
-            : $request->input('ttl');
-
         // Only MX & SRV types use Priority
         $record->priority = ($request->input('type') == 'MX' || $request->input('type') == 'SRV')
             ? $request->input('priority')
@@ -103,11 +98,6 @@ class RecordController extends Controller
      */
     public function update(RecordUpdateRequest $request, Zone $zone, Record $record)
     {
-        // If user doesn't supply a TTL we must use default's one
-        $record->ttl = ($request->input('ttl') == '')
-            ? \Registry::get('record_ttl_default')
-            : $request->input('ttl');
-
         // Only MX & SRV types use Priority
         $record->priority = ($record->type == 'MX' || $record->type == 'SRV')
             ? $request->input('priority')

--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -32,6 +32,6 @@ class SettingsController extends Controller
         Registry::store($request->except('_token', '_method'));
 
         return redirect()->route('settings.index')
-            ->with('success', trans('settings/messages.save.success'));
+            ->with('success', trans('settings/messages.update.success'));
     }
 }

--- a/app/Http/Controllers/ZoneController.php
+++ b/app/Http/Controllers/ZoneController.php
@@ -49,6 +49,8 @@ class ZoneController extends Controller
             $zone->serial = Zone::createSerialNumber();
             $zone->updated = true;
         }
+        // deal with checkboxes
+        $zone->custom_settings = $request->input('custom_settings', 0);
 
         $zone->fill($request->all())->save();
 
@@ -94,6 +96,9 @@ class ZoneController extends Controller
             $zone->setSerialNumber();
             $zone->updated = true;
         }
+        // deal with checkboxes
+        $zone->custom_settings = $request->input('custom_settings', 0);
+
         $zone->fill($request->all())->save();
 
         return redirect()->route('zones.index')

--- a/app/Http/Requests/ServerCreateRequest.php
+++ b/app/Http/Requests/ServerCreateRequest.php
@@ -28,7 +28,6 @@ class ServerCreateRequest extends Request
             'ip_address'   => 'required|ip|unique:servers',
             'type'         => 'required|in:master,slave',
             'ns_record'    => 'sometimes|boolean',
-            'active'       => 'required|boolean',
             'push_updates' => 'sometimes|boolean',
             'directory'    => 'required_if:push_updates,1|string',
             'template'     => 'required_if:push_updates,1|string',

--- a/app/Http/Requests/SettingsUpdateRequest.php
+++ b/app/Http/Requests/SettingsUpdateRequest.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Requests;
 
-use App\Http\Requests\Request;
-
 class SettingsUpdateRequest extends Request
 {
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -24,13 +23,13 @@ class SettingsUpdateRequest extends Request
     public function rules()
     {
         return [
-            'zone_default.mname'       => 'required|string',
-            'zone_default.rname'       => 'required|email',
-            'zone_default.refresh'     => 'required|integer',
-            'zone_default.retry'       => 'required|integer',
-            'zone_default.expire'      => 'required|integer',
-            'zone_default.minimum_ttl' => 'required|integer|min:0|max:2147483647',
-            'record_ttl_default'       => 'required|integer|min:0|max:2147483647'
+            'zone_default.mname'        => 'required|string',
+            'zone_default.rname'        => 'required|email',
+            'zone_default.refresh'      => 'required|integer',
+            'zone_default.retry'        => 'required|integer',
+            'zone_default.expire'       => 'required|integer',
+            'zone_default.negative_ttl' => 'required|integer|min:0|max:2147483647',
+            'zone_default.default_ttl'  => 'required|integer|min:0|max:2147483647',
         ];
     }
 }

--- a/app/Http/Requests/SettingsUpdateRequest.php
+++ b/app/Http/Requests/SettingsUpdateRequest.php
@@ -23,13 +23,13 @@ class SettingsUpdateRequest extends Request
     public function rules()
     {
         return [
-            'zone_default.mname'        => 'required|string',
-            'zone_default.rname'        => 'required|email',
-            'zone_default.refresh'      => 'required|integer',
-            'zone_default.retry'        => 'required|integer',
-            'zone_default.expire'       => 'required|integer',
-            'zone_default.negative_ttl' => 'required|integer|min:0|max:2147483647',
-            'zone_default.default_ttl'  => 'required|integer|min:0|max:2147483647',
+            'zone_default_mname'        => 'required|string',
+            'zone_default_rname'        => 'required|email',
+            'zone_default_refresh'      => 'required|integer',
+            'zone_default_retry'        => 'required|integer',
+            'zone_default_expire'       => 'required|integer',
+            'zone_default_negative_ttl' => 'required|integer|min:0|max:2147483647',
+            'zone_default_default_ttl'  => 'required|integer|min:0|max:2147483647',
         ];
     }
 }

--- a/app/Http/Requests/ZoneCreateRequest.php
+++ b/app/Http/Requests/ZoneCreateRequest.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Requests;
 
-use App\Http\Requests\Request;
-
 class ZoneCreateRequest extends Request
 {
+
     /**
      * Determine if the user is authorized to make this request.
      *
@@ -24,8 +23,14 @@ class ZoneCreateRequest extends Request
     public function rules()
     {
         return [
-            'domain' => 'required|string|unique:zones',
-            'master' => 'sometimes|required|ip',
+            'domain'          => 'required|string|unique:zones',
+            'master'          => 'sometimes|required|ip',
+            'custom_settings' => 'sometimes|boolean',
+            'refresh'         => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'retry'           => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'expire'          => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'negative_ttl'    => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'default_ttl'     => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
         ];
     }
 }

--- a/app/Http/Requests/ZoneUpdateRequest.php
+++ b/app/Http/Requests/ZoneUpdateRequest.php
@@ -25,8 +25,14 @@ class ZoneUpdateRequest extends Request
         $zone = $this->route('zone');
 
         return [
-            'domain' => 'required|string|unique:zones,domain,' . $zone->id,
-            'master' => 'sometimes|required|ip',
+            'domain'          => 'required|string|unique:zones,domain,' . $zone->id,
+            'master'          => 'sometimes|required|ip',
+            'custom_settings' => 'sometimes|boolean',
+            'refresh'         => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'retry'           => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'expire'          => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'negative_ttl'    => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
+            'default_ttl'     => 'required_if:custom_settings,1|integer|min:0|max:2147483647',
         ];
     }
 }

--- a/app/Record.php
+++ b/app/Record.php
@@ -40,7 +40,8 @@ class Record extends Model
     protected $fillable = [
         'name',
         'type',
-        'data'
+        'ttl',
+        'data',
     ];
     /**
      * The attributes that should be casted to native types.

--- a/app/Zone.php
+++ b/app/Zone.php
@@ -174,7 +174,7 @@ class Zone extends Model
      */
     public function getRefresh()
     {
-        return intval(($this->custom_settings) ? $this->refresh : \Registry::get('zone_default.refresh'));
+        return intval(($this->custom_settings) ? $this->refresh : \Registry::get('zone_default_refresh'));
     }
 
     /**
@@ -184,7 +184,7 @@ class Zone extends Model
      */
     public function getRetry()
     {
-        return intval(($this->custom_settings) ? $this->retry : \Registry::get('zone_default.retry'));
+        return intval(($this->custom_settings) ? $this->retry : \Registry::get('zone_default_retry'));
     }
 
     /**
@@ -194,7 +194,7 @@ class Zone extends Model
      */
     public function getExpire()
     {
-        return intval(($this->custom_settings) ? $this->expire : \Registry::get('zone_default.expire'));
+        return intval(($this->custom_settings) ? $this->expire : \Registry::get('zone_default_expire'));
     }
 
     /**
@@ -204,7 +204,7 @@ class Zone extends Model
      */
     public function getNegativeTTL()
     {
-        return intval(($this->custom_settings) ? $this->negative_ttl : \Registry::get('zone_default.negative_ttl'));
+        return intval(($this->custom_settings) ? $this->negative_ttl : \Registry::get('zone_default_negative_ttl'));
     }
 
     /**
@@ -214,6 +214,6 @@ class Zone extends Model
      */
     public function getDefaultTTL()
     {
-        return intval(($this->custom_settings) ? $this->default_ttl : \Registry::get('zone_default.default_ttl'));
+        return intval(($this->custom_settings) ? $this->default_ttl : \Registry::get('zone_default_default_ttl'));
     }
 }

--- a/app/Zone.php
+++ b/app/Zone.php
@@ -13,6 +13,12 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $domain
  * @property integer $serial
  * @property string $master
+ * @property boolean $custom_settings
+ * @property integer $refresh
+ * @property integer $retry
+ * @property integer $expire
+ * @property integer $negative_ttl
+ * @property integer $default_ttl
  * @property boolean $updated
  */
 class Zone extends Model
@@ -33,6 +39,11 @@ class Zone extends Model
     protected $fillable = [
         'domain',
         'master',
+        'refresh',
+        'retry',
+        'expire',
+        'negative_ttl',
+        'default_ttl'
     ];
     /**
      * The attributes that should be casted to native types.
@@ -40,10 +51,16 @@ class Zone extends Model
      * @var array
      */
     protected $casts = [
-        'domain'  => 'string',
-        'serial'  => 'integer',
-        'master'  => 'string',
-        'updated' => 'boolean',
+        'domain'          => 'string',
+        'serial'          => 'integer',
+        'master'          => 'string',
+        'updated'         => 'boolean',
+        'custom_settings' => 'boolean',
+        'refresh'         => 'integer',
+        'retry'           => 'integer',
+        'expire'          => 'integer',
+        'negative_ttl'    => 'integer',
+        'default_ttl'     => 'integer',
     ];
 
     /**
@@ -148,5 +165,55 @@ class Zone extends Model
     public function hasPendingChanges()
     {
         return $this->updated;
+    }
+
+    /**
+     * Returns the Refresh time for this zone
+     *
+     * @return int
+     */
+    public function getRefresh()
+    {
+        return intval(($this->custom_settings) ? $this->refresh : \Registry::get('zone_default.refresh'));
+    }
+
+    /**
+     * Returns the Retry time for this zone
+     *
+     * @return int
+     */
+    public function getRetry()
+    {
+        return intval(($this->custom_settings) ? $this->retry : \Registry::get('zone_default.retry'));
+    }
+
+    /**
+     * Returns the Expire time for this zone
+     *
+     * @return int
+     */
+    public function getExpire()
+    {
+        return intval(($this->custom_settings) ? $this->expire : \Registry::get('zone_default.expire'));
+    }
+
+    /**
+     * Returns the Negative TTL for this zone
+     *
+     * @return int
+     */
+    public function getNegativeTTL()
+    {
+        return intval(($this->custom_settings) ? $this->negative_ttl : \Registry::get('zone_default.negative_ttl'));
+    }
+
+    /**
+     * Returns the Default TTL for this zone
+     *
+     * @return int
+     */
+    public function getDefaultTTL()
+    {
+        return intval(($this->custom_settings) ? $this->default_ttl : \Registry::get('zone_default.default_ttl'));
     }
 }

--- a/database/migrations/2016_08_05_100108_create_zones_table.php
+++ b/database/migrations/2016_08_05_100108_create_zones_table.php
@@ -18,6 +18,14 @@ class CreateZonesTable extends Migration
             $table->integer('serial')->unsigned();
             $table->string('master', 45)->nullable();
             $table->boolean('updated')->default(true);
+
+            $table->boolean('custom_settings')->default(false);
+            $table->integer('refresh')->unsigned()->nullable();
+            $table->integer('retry')->unsigned()->nullable();
+            $table->integer('expire')->unsigned()->nullable();
+            $table->integer('negative_ttl')->unsigned()->nullable();
+            $table->integer('default_ttl')->unsigned()->nullable();
+
             $table->softDeletes();
             $table->timestamps();
         });

--- a/database/seeds/SettingsTableSeeder.php
+++ b/database/seeds/SettingsTableSeeder.php
@@ -5,6 +5,7 @@ use Torann\Registry\Facades\Registry;
 
 class SettingsTableSeeder extends Seeder
 {
+
     /**
      * Run the database seeds.
      *
@@ -18,19 +19,15 @@ class SettingsTableSeeder extends Seeder
             /*
              * Default values for Zone's definition
              */
-            'zone_default'       => [
-                'mname'       => 'dns1.domain.local', // Default MNAME, hostname of master DNS
-                'rname'       => 'hostmaster@domain.local', // Default RNAME, email of hostmaster
-                'refresh'     => '86400', // 24 hours
-                'retry'       => '7200', // 2 hours
-                'expire'      => '3628800', // 6 weeks
-                'minimum_ttl' => '7200', // 2 hours
+            'zone_default' => [
+                'mname'        => 'dns1.domain.local', // Default MNAME, hostname of master DNS
+                'rname'        => 'hostmaster@domain.local', // Default RNAME, email of hostmaster
+                'refresh'      => '86400', // 24 hours
+                'retry'        => '7200', // 2 hours
+                'expire'       => '3628800', // 6 weeks
+                'negative_ttl' => '7200', // 2 hours
+                'default_ttl'  => '172800' // 48 hours
             ],
-
-            /*
-             * Default TTL for resource records
-             */
-            'record_ttl_default' => '172800', // 48 hours
         ];
 
         Registry::store($settings);

--- a/resources/lang/en/settings/model.php
+++ b/resources/lang/en/settings/model.php
@@ -1,26 +1,24 @@
 <?php
 
 return [
-    'zone_default' => [
-        'mname'      => 'SOA Primary Server',
-        'mname_help' => 'The fully qualified domain name for the name server.',
+    'zone_default_mname'      => 'SOA Primary Server',
+    'zone_default_mname_help' => 'The fully qualified domain name for the name server.',
 
-        'rname'      => 'Responsible Person',
-        'rname_help' => ' The e-mail address of the person in charge of the domain.',
+    'zone_default_rname'      => 'Responsible Person',
+    'zone_default_rname_help' => ' The e-mail address of the person in charge of the domain.',
 
-        'refresh'      => 'Refresh time (seconds)',
-        'refresh_help' => 'Sets how often the zone should be synchronized from master name server to slave name server.',
+    'zone_default_refresh'      => 'Refresh time (seconds)',
+    'zone_default_refresh_help' => 'Sets how often the zone should be synchronized from master name server to slave name server.',
 
-        'retry'      => 'Retry time (seconds)',
-        'retry_help' => 'Sets how often slave name servers try to synchronize the zone from master name server if synchronization fails.',
+    'zone_default_retry'      => 'Retry time (seconds)',
+    'zone_default_retry_help' => 'Sets how often slave name servers try to synchronize the zone from master name server if synchronization fails.',
 
-        'expire'      => 'Expiration (seconds)',
-        'expire_help' => 'Means the period after which the zone expires on slave name servers and slave name servers and slave server stop answering replies until it is synchronized.',
+    'zone_default_expire'      => 'Expiration (seconds)',
+    'zone_default_expire_help' => 'Means the period after which the zone expires on slave name servers and slave name servers and slave server stop answering replies until it is synchronized.',
 
-        'negative_ttl'      => 'Negative Answers TTL (seconds)',
-        'negative_ttl_help' => 'Specifies the time to live in the zone for caching negative answers on slave servers.',
+    'zone_default_negative_ttl'      => 'Negative Answers TTL (seconds)',
+    'zone_default_negative_ttl_help' => 'Specifies the time to live in the zone for caching negative answers on slave servers.',
 
-        'default_ttl'      => 'Default TTL for records (seconds)',
-        'default_ttl_help' => 'Specifies the time to live for all records in the zone that do not have an explicit TTL.',
-    ],
+    'zone_default_default_ttl'      => 'Default TTL for records (seconds)',
+    'zone_default_default_ttl_help' => 'Specifies the time to live for all records in the zone that do not have an explicit TTL.',
 ];

--- a/resources/lang/en/settings/model.php
+++ b/resources/lang/en/settings/model.php
@@ -1,27 +1,26 @@
 <?php
 
 return [
-
-    'zone_default'            => [
+    'zone_default' => [
         'mname'      => 'SOA Primary Server',
         'mname_help' => 'The fully qualified domain name for the name server.',
 
         'rname'      => 'Responsible Person',
         'rname_help' => ' The e-mail address of the person in charge of the domain.',
 
-        'refresh'      => 'Refresh Interval',
-        'refresh_help' => 'The interval at which a secondary server checks for zone updates.',
+        'refresh'      => 'Refresh time (seconds)',
+        'refresh_help' => 'Sets how often the zone should be synchronized from master name server to slave name server.',
 
-        'retry'      => 'Retry Interval',
-        'retry_help' => 'The time the secondary server waits after a failure to download the zone database.',
+        'retry'      => 'Retry time (seconds)',
+        'retry_help' => 'Sets how often slave name servers try to synchronize the zone from master name server if synchronization fails.',
 
-        'expire'      => 'Expires After',
-        'expire_help' => 'The period of time for which zone information is valid on the secondary server.',
+        'expire'      => 'Expiration (seconds)',
+        'expire_help' => 'Means the period after which the zone expires on slave name servers and slave name servers and slave server stop answering replies until it is synchronized.',
 
-        'minimum_ttl'      => 'Minimum (Default) TTL',
-        'minimum_ttl_help' => 'The minimum time-to-live value for cached records on a DNS server.',
+        'negative_ttl'      => 'Negative Answers TTL (seconds)',
+        'negative_ttl_help' => 'Specifies the time to live in the zone for caching negative answers on slave servers.',
+
+        'default_ttl'      => 'Default TTL for records (seconds)',
+        'default_ttl_help' => 'Specifies the time to live for all records in the zone that do not have an explicit TTL.',
     ],
-    'record_ttl_default'      => 'TTL',
-    'record_ttl_default_help' => 'The default time-to-live value for all resource records.',
-
 ];

--- a/resources/lang/en/settings/title.php
+++ b/resources/lang/en/settings/title.php
@@ -3,4 +3,5 @@
 return [
     'settings_management'          => 'Settings Management',
     'settings_management_subtitle' => '',
+    'zone_settings'                => 'Zone Global Settings',
 ];

--- a/resources/lang/en/zone/model.php
+++ b/resources/lang/en/zone/model.php
@@ -1,14 +1,28 @@
 <?php
 
 return [
-
-    'domain' => 'Domain',
-    'serial' => 'Serial',
-    'master' => 'Master DNS',
-    'type'   => 'Type',
-    'types'  => [
+    'domain'          => 'Domain',
+    'serial'          => 'Serial',
+    'master'          => 'Master DNS',
+    'type'            => 'Type',
+    'types'           => [
         'master' => 'Master',
         'slave'  => 'Slave'
     ],
+    'custom_settings' => 'Use zone specific settings',
 
+    'refresh'      => 'Refresh time (seconds)',
+    'refresh_help' => 'Sets how often the zone should be synchronized from master name server to slave name server.',
+
+    'retry'      => 'Retry time (seconds)',
+    'retry_help' => 'Sets how often slave name servers try to synchronize the zone from master name server if synchronization fails.',
+
+    'expire'      => 'Expiration (seconds)',
+    'expire_help' => 'Means the period after which the zone expires on slave name servers and slave name servers and slave server stop answering replies until it is synchronized.',
+
+    'negative_ttl'      => 'Negative Answers TTL (seconds)',
+    'negative_ttl_help' => 'Specifies the time to live in the zone for caching negative answers on slave servers.',
+
+    'default_ttl'      => 'Default TTL for records (seconds)',
+    'default_ttl_help' => 'Specifies the time to live for all records in the zone that do not have an explicit TTL.',
 ];

--- a/resources/lang/en/zone/title.php
+++ b/resources/lang/en/zone/title.php
@@ -8,4 +8,5 @@ return [
     'create_new_subtitle'      => 'create a new zone',
     'zone_edit'                => 'Edit Zone',
     'zone_delete'              => 'Delete Zone',
+    'custom_settings'          => 'Zone specific settings',
 ];

--- a/resources/views/settings/_form.blade.php
+++ b/resources/views/settings/_form.blade.php
@@ -1,133 +1,116 @@
 {{-- Edit Settings Form --}}
 {!! Form::open(['route' => ['settings.update'], 'method' => 'put']) !!}
 
+<div class="nav-tabs-custom">
 
-<div class="box">
-    <div class="box-body">
-        <div class="nav-tabs-custom">
+    <ul class="nav nav-tabs">
+        <li class="active">
+            <a href="#panel_settings_tab1" data-toggle="tab">
+                {{ trans('settings/title.zone_settings') }}
+            </a>
+        </li>
+    </ul>
 
-            <ul class="nav nav-tabs">
-                <li class="active">
-                    <a href="#panel_settings_tab1" data-toggle="tab">
-                        Zone's defaults
-                    </a>
-                </li>
-                <li>
-                    <a href="#panel_settings_tab2" data-toggle="tab">
-                        Tab 2
-                    </a>
-                </li>
-            </ul>
+    <div class="tab-content">
 
-            <div class="tab-content">
+        <!-- Zone global settings panel -->
+        <div class="tab-pane active" id="panel_settings_tab1">
 
-                <!-- Zone's defaults settings -->
-                <div class="tab-pane active" id="panel_settings_tab1">
+            <p>{{ trans('settings/messages.zone_defaults_information') }}</p>
 
-                    <p>{{ trans('settings/messages.zone_defaults_information') }}</p>
-
-                    <!-- zone_default.mname -->
-                    <div class="form-group {{ $errors->has('zone_default.mname') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.mname', trans('settings/model.zone_default.mname'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::text('zone_default.mname', Registry::get('zone_default.mname'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.mname_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.mname', ':message') }}</span>
-                        </div>
-                    </div>
-                    <!-- ./ zone_default.mname  -->
-
-                    <!-- zone_default.rname -->
-                    <div class="form-group {{ $errors->has('zone_default.rname') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.rname', trans('settings/model.zone_default.rname'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::email('zone_default.rname', Registry::get('zone_default.rname'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.rname_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.rname', ':message') }}</span>
-                        </div>
-                    </div>
-                    <!-- ./ zone_default.rname  -->
-
-                    <div class="row">
-                        <div class="col-md-6">
-                            <!-- zone_default.refresh -->
-                            <div class="form-group {{ $errors->has('zone_default.refresh') ? 'has-error' : '' }}">
-                                {!! Form::label('zone_default.refresh', trans('settings/model.zone_default.refresh'), array('class' => 'control-label')) !!}
-                                <div class="controls">
-                                    {!! Form::number('zone_default.refresh', Registry::get('zone_default.refresh'), array('class' => 'form-control')) !!}
-                                    <span class="help-block">{{ trans('settings/model.zone_default.refresh_help') }}</span>
-                                    <span class="help-block">{{ $errors->first('zone_default.refresh', ':message') }}</span>
-                                </div>
-                            </div>
-                            <!-- ./ zone_default.refresh -->
-                        </div>
-                        <div class="col-md-6">
-                            <!-- zone_default.retry -->
-                            <div class="form-group {{ $errors->has('zone_default.retry') ? 'has-error' : '' }}">
-                                {!! Form::label('zone_default.retry', trans('settings/model.zone_default.retry'), array('class' => 'control-label')) !!}
-                                <div class="controls">
-                                    {!! Form::number('zone_default.retry', Registry::get('zone_default.retry'), array('class' => 'form-control')) !!}
-                                    <span class="help-block">{{ trans('settings/model.zone_default.retry_help') }}</span>
-                                    <span class="help-block">{{ $errors->first('zone_default.retry', ':message') }}</span>
-                                </div>
-                            </div>
-                            <!-- ./ zone_default.retry -->
-                        </div>
-                    </div>
-
-                    <div class="row">
-                        <div class="col-md-6">
-                            <!-- zone_default.expire -->
-                            <div class="form-group {{ $errors->has('zone_default.expire') ? 'has-error' : '' }}">
-                                {!! Form::label('zone_default.expire', trans('settings/model.zone_default.expire'), array('class' => 'control-label')) !!}
-                                <div class="controls">
-                                    {!! Form::number('zone_default.expire', Registry::get('zone_default.expire'), array('class' => 'form-control')) !!}
-                                    <span class="help-block">{{ trans('settings/model.zone_default.expire_help') }}</span>
-                                    <span class="help-block">{{ $errors->first('zone_default.expire', ':message') }}</span>
-                                </div>
-                            </div>
-                            <!-- ./ zone_default.expire -->
-                        </div>
-                        <div class="col-md-6">
-                            <!-- zone_default.negative_ttl -->
-                            <div class="form-group {{ $errors->has('zone_default.negative_ttl') ? 'has-error' : '' }}">
-                                {!! Form::label('zone_default.negative_ttl', trans('settings/model.zone_default.negative_ttl'), array('class' => 'control-label')) !!}
-                                <div class="controls">
-                                    {!! Form::number('zone_default.negative_ttl', Registry::get('zone_default.negative_ttl'), array('class' => 'form-control')) !!}
-                                    <span class="help-block">{{ trans('settings/model.zone_default.negative_ttl_help') }}</span>
-                                    <span class="help-block">{{ $errors->first('zone_default.negative_ttl', ':message') }}</span>
-                                </div>
-                            </div>
-                            <!-- ./ zone_default.negative_ttl -->
-                        </div>
-                    </div>
-
-                    <!-- zone_default.default_ttl -->
-                    <div class="form-group {{ $errors->has('zone_default.default_ttl') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.default_ttl', trans('settings/model.zone_default.default_ttl'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::number('zone_default.default_ttl', Registry::get('zone_default.default_ttl'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.default_ttl_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.default_ttl', ':message') }}</span>
-                        </div>
-                    </div>
-                    <!-- ./ zone_default.default_ttl -->
+            <!-- zone_default_mname -->
+            <div class="form-group {{ $errors->has('zone_default_mname') ? 'has-error' : '' }}">
+                {!! Form::label('zone_default_mname', trans('settings/model.zone_default_mname'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {!! Form::text('zone_default_mname', Registry::get('zone_default_mname'), array('class' => 'form-control')) !!}
+                    <span class="help-block">{{ trans('settings/model.zone_default_mname_help') }}</span>
+                    <span class="help-block">{{ $errors->first('zone_default_mname', ':message') }}</span>
                 </div>
-                <!-- ./ Zone's defaults settings -->
-
-                <!-- RR's defaults settings -->
-                <div class="tab-pane" id="panel_settings_tab2">
-
-                </div>
-                <!-- ./ RR's defaults settings -->
-
             </div>
+            <!-- ./ zone_default_mname  -->
+
+            <!-- zone_default_rname -->
+            <div class="form-group {{ $errors->has('zone_default_rname') ? 'has-error' : '' }}">
+                {!! Form::label('zone_default_rname', trans('settings/model.zone_default_rname'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {!! Form::email('zone_default_rname', Registry::get('zone_default_rname'), array('class' => 'form-control')) !!}
+                    <span class="help-block">{{ trans('settings/model.zone_default_rname_help') }}</span>
+                    <span class="help-block">{{ $errors->first('zone_default_rname', ':message') }}</span>
+                </div>
+            </div>
+            <!-- ./ zone_default_rname  -->
+
+            <div class="row">
+                <div class="col-md-6">
+                    <!-- zone_default_refresh -->
+                    <div class="form-group {{ $errors->has('zone_default_refresh') ? 'has-error' : '' }}">
+                        {!! Form::label('zone_default_refresh', trans('settings/model.zone_default_refresh'), array('class' => 'control-label')) !!}
+                        <div class="controls">
+                            {!! Form::number('zone_default_refresh', Registry::get('zone_default_refresh'), array('class' => 'form-control')) !!}
+                            <span class="help-block">{{ trans('settings/model.zone_default_refresh_help') }}</span>
+                            <span class="help-block">{{ $errors->first('zone_default_refresh', ':message') }}</span>
+                        </div>
+                    </div>
+                    <!-- ./ zone_default_refresh -->
+                </div>
+                <div class="col-md-6">
+                    <!-- zone_default_retry -->
+                    <div class="form-group {{ $errors->has('zone_default_retry') ? 'has-error' : '' }}">
+                        {!! Form::label('zone_default_retry', trans('settings/model.zone_default_retry'), array('class' => 'control-label')) !!}
+                        <div class="controls">
+                            {!! Form::number('zone_default_retry', Registry::get('zone_default_retry'), array('class' => 'form-control')) !!}
+                            <span class="help-block">{{ trans('settings/model.zone_default_retry_help') }}</span>
+                            <span class="help-block">{{ $errors->first('zone_default_retry', ':message') }}</span>
+                        </div>
+                    </div>
+                    <!-- ./ zone_default_retry -->
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-md-6">
+                    <!-- zone_default_expire -->
+                    <div class="form-group {{ $errors->has('zone_default_expire') ? 'has-error' : '' }}">
+                        {!! Form::label('zone_default_expire', trans('settings/model.zone_default_expire'), array('class' => 'control-label')) !!}
+                        <div class="controls">
+                            {!! Form::number('zone_default_expire', Registry::get('zone_default_expire'), array('class' => 'form-control')) !!}
+                            <span class="help-block">{{ trans('settings/model.zone_default_expire_help') }}</span>
+                            <span class="help-block">{{ $errors->first('zone_default_expire', ':message') }}</span>
+                        </div>
+                    </div>
+                    <!-- ./ zone_default_expire -->
+                </div>
+                <div class="col-md-6">
+                    <!-- zone_default_negative_ttl -->
+                    <div class="form-group {{ $errors->has('zone_default_negative_ttl') ? 'has-error' : '' }}">
+                        {!! Form::label('zone_default_negative_ttl', trans('settings/model.zone_default_negative_ttl'), array('class' => 'control-label')) !!}
+                        <div class="controls">
+                            {!! Form::number('zone_default_negative_ttl', Registry::get('zone_default_negative_ttl'), array('class' => 'form-control')) !!}
+                            <span class="help-block">{{ trans('settings/model.zone_default_negative_ttl_help') }}</span>
+                            <span class="help-block">{{ $errors->first('zone_default_negative_ttl', ':message') }}</span>
+                        </div>
+                    </div>
+                    <!-- ./ zone_default_negative_ttl -->
+                </div>
+            </div>
+
+            <!-- zone_default_default_ttl -->
+            <div class="form-group {{ $errors->has('zone_default_default_ttl') ? 'has-error' : '' }}">
+                {!! Form::label('zone_default_default_ttl', trans('settings/model.zone_default_default_ttl'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {!! Form::number('zone_default_default_ttl', Registry::get('zone_default_default_ttl'), array('class' => 'form-control')) !!}
+                    <span class="help-block">{{ trans('settings/model.zone_default_default_ttl_help') }}</span>
+                    <span class="help-block">{{ $errors->first('zone_default_default_ttl', ':message') }}</span>
+                </div>
+            </div>
+            <!-- ./ zone_default_default_ttl -->
         </div>
-    </div>
-    <div class="box-footer">
-        <!-- Form Actions -->
-    {!! Form::button('<i class="fa fa-floppy-o"></i> ' . trans('general.save'), array('type' => 'submit', 'class' => 'btn btn-success')) !!}
-    <!-- ./ form actions -->
+        <!-- ./ Zone global settings panel -->
+
     </div>
 </div>
+
+<!-- Form Actions -->
+{!! Form::button('<i class="fa fa-floppy-o"></i> ' . trans('general.save'), array('type' => 'submit', 'class' => 'btn btn-success')) !!}
+<!-- ./ form actions -->
 {!! Form::close() !!}

--- a/resources/views/settings/_form.blade.php
+++ b/resources/views/settings/_form.blade.php
@@ -14,7 +14,7 @@
                 </li>
                 <li>
                     <a href="#panel_settings_tab2" data-toggle="tab">
-                        RR's defaults
+                        Tab 2
                     </a>
                 </li>
             </ul>
@@ -48,64 +48,76 @@
                     </div>
                     <!-- ./ zone_default.rname  -->
 
-                    <!-- zone_default.refresh -->
-                    <div class="form-group {{ $errors->has('zone_default.refresh') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.refresh', trans('settings/model.zone_default.refresh'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::number('zone_default.refresh', Registry::get('zone_default.refresh'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.refresh_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.refresh', ':message') }}</span>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <!-- zone_default.refresh -->
+                            <div class="form-group {{ $errors->has('zone_default.refresh') ? 'has-error' : '' }}">
+                                {!! Form::label('zone_default.refresh', trans('settings/model.zone_default.refresh'), array('class' => 'control-label')) !!}
+                                <div class="controls">
+                                    {!! Form::number('zone_default.refresh', Registry::get('zone_default.refresh'), array('class' => 'form-control')) !!}
+                                    <span class="help-block">{{ trans('settings/model.zone_default.refresh_help') }}</span>
+                                    <span class="help-block">{{ $errors->first('zone_default.refresh', ':message') }}</span>
+                                </div>
+                            </div>
+                            <!-- ./ zone_default.refresh -->
+                        </div>
+                        <div class="col-md-6">
+                            <!-- zone_default.retry -->
+                            <div class="form-group {{ $errors->has('zone_default.retry') ? 'has-error' : '' }}">
+                                {!! Form::label('zone_default.retry', trans('settings/model.zone_default.retry'), array('class' => 'control-label')) !!}
+                                <div class="controls">
+                                    {!! Form::number('zone_default.retry', Registry::get('zone_default.retry'), array('class' => 'form-control')) !!}
+                                    <span class="help-block">{{ trans('settings/model.zone_default.retry_help') }}</span>
+                                    <span class="help-block">{{ $errors->first('zone_default.retry', ':message') }}</span>
+                                </div>
+                            </div>
+                            <!-- ./ zone_default.retry -->
                         </div>
                     </div>
-                    <!-- ./ zone_default.refresh -->
 
-                    <!-- zone_default.retry -->
-                    <div class="form-group {{ $errors->has('zone_default.retry') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.retry', trans('settings/model.zone_default.retry'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::number('zone_default.retry', Registry::get('zone_default.retry'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.retry_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.retry', ':message') }}</span>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <!-- zone_default.expire -->
+                            <div class="form-group {{ $errors->has('zone_default.expire') ? 'has-error' : '' }}">
+                                {!! Form::label('zone_default.expire', trans('settings/model.zone_default.expire'), array('class' => 'control-label')) !!}
+                                <div class="controls">
+                                    {!! Form::number('zone_default.expire', Registry::get('zone_default.expire'), array('class' => 'form-control')) !!}
+                                    <span class="help-block">{{ trans('settings/model.zone_default.expire_help') }}</span>
+                                    <span class="help-block">{{ $errors->first('zone_default.expire', ':message') }}</span>
+                                </div>
+                            </div>
+                            <!-- ./ zone_default.expire -->
+                        </div>
+                        <div class="col-md-6">
+                            <!-- zone_default.negative_ttl -->
+                            <div class="form-group {{ $errors->has('zone_default.negative_ttl') ? 'has-error' : '' }}">
+                                {!! Form::label('zone_default.negative_ttl', trans('settings/model.zone_default.negative_ttl'), array('class' => 'control-label')) !!}
+                                <div class="controls">
+                                    {!! Form::number('zone_default.negative_ttl', Registry::get('zone_default.negative_ttl'), array('class' => 'form-control')) !!}
+                                    <span class="help-block">{{ trans('settings/model.zone_default.negative_ttl_help') }}</span>
+                                    <span class="help-block">{{ $errors->first('zone_default.negative_ttl', ':message') }}</span>
+                                </div>
+                            </div>
+                            <!-- ./ zone_default.negative_ttl -->
                         </div>
                     </div>
-                    <!-- ./ zone_default.retry -->
 
-                    <!-- zone_default.expire -->
-                    <div class="form-group {{ $errors->has('zone_default.expire') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.expire', trans('settings/model.zone_default.expire'), array('class' => 'control-label')) !!}
+                    <!-- zone_default.default_ttl -->
+                    <div class="form-group {{ $errors->has('zone_default.default_ttl') ? 'has-error' : '' }}">
+                        {!! Form::label('zone_default.default_ttl', trans('settings/model.zone_default.default_ttl'), array('class' => 'control-label')) !!}
                         <div class="controls">
-                            {!! Form::number('zone_default.expire', Registry::get('zone_default.expire'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.expire_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.expire', ':message') }}</span>
+                            {!! Form::number('zone_default.default_ttl', Registry::get('zone_default.default_ttl'), array('class' => 'form-control')) !!}
+                            <span class="help-block">{{ trans('settings/model.zone_default.default_ttl_help') }}</span>
+                            <span class="help-block">{{ $errors->first('zone_default.default_ttl', ':message') }}</span>
                         </div>
                     </div>
-                    <!-- ./ zone_default.expire -->
-
-                    <!-- zone_default.minimum_ttl -->
-                    <div class="form-group {{ $errors->has('zone_default.minimum_ttl') ? 'has-error' : '' }}">
-                        {!! Form::label('zone_default.minimum_ttl', trans('settings/model.zone_default.minimum_ttl'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::number('zone_default.minimum_ttl', Registry::get('zone_default.minimum_ttl'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.zone_default.minimum_ttl_help') }}</span>
-                            <span class="help-block">{{ $errors->first('zone_default.minimum_ttl', ':message') }}</span>
-                        </div>
-                    </div>
-                    <!-- ./ zone_default.minimum_ttl -->
+                    <!-- ./ zone_default.default_ttl -->
                 </div>
                 <!-- ./ Zone's defaults settings -->
 
                 <!-- RR's defaults settings -->
                 <div class="tab-pane" id="panel_settings_tab2">
-                    <!-- record_ttl_default -->
-                    <div class="form-group {{ $errors->has('record_ttl_default') ? 'has-error' : '' }}">
-                        {!! Form::label('record_ttl_default', trans('settings/model.record_ttl_default'), array('class' => 'control-label')) !!}
-                        <div class="controls">
-                            {!! Form::number('record_ttl_default', Registry::get('record_ttl_default'), array('class' => 'form-control')) !!}
-                            <span class="help-block">{{ trans('settings/model.record_ttl_default_help') }}</span>
-                            <span class="help-block">{{ $errors->first('record_ttl_default', ':message') }}</span>
-                        </div>
-                    </div>
-                    <!-- ./ record_ttl_default -->
+
                 </div>
                 <!-- ./ RR's defaults settings -->
 
@@ -113,7 +125,7 @@
         </div>
     </div>
     <div class="box-footer">
-    <!-- Form Actions -->
+        <!-- Form Actions -->
     {!! Form::button('<i class="fa fa-floppy-o"></i> ' . trans('general.save'), array('type' => 'submit', 'class' => 'btn btn-success')) !!}
     <!-- ./ form actions -->
     </div>

--- a/resources/views/zone/_details_master.blade.php
+++ b/resources/views/zone/_details_master.blade.php
@@ -28,6 +28,56 @@
         </div>
         <!-- ./ serial -->
 
+        @if($zone->custom_settings)
+
+            <h4>{{ trans('zone/title.custom_settings') }}</h4>
+
+            <!-- refresh -->
+            <div class="form-group">
+                {!! Form::label('refresh', trans('zone/model.refresh'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {{ $zone->refresh }}
+                </div>
+            </div>
+            <!-- ./ refresh -->
+
+            <!-- retry -->
+            <div class="form-group">
+                {!! Form::label('retry', trans('zone/model.retry'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {{ $zone->retry }}
+                </div>
+            </div>
+            <!-- ./ retry -->
+
+            <!-- expire -->
+            <div class="form-group">
+                {!! Form::label('expire', trans('zone/model.expire'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {{ $zone->expire }}
+                </div>
+            </div>
+            <!-- ./ expire -->
+
+            <!-- negative_ttl -->
+            <div class="form-group">
+                {!! Form::label('negative_ttl', trans('zone/model.negative_ttl'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {{ $zone->negative_ttl }}
+                </div>
+            </div>
+            <!-- ./ negative_ttl -->
+
+            <!-- default_ttl -->
+            <div class="form-group">
+                {!! Form::label('default_ttl', trans('zone/model.default_ttl'), array('class' => 'control-label')) !!}
+                <div class="controls">
+                    {{ $zone->default_ttl }}
+                </div>
+            </div>
+            <!-- ./ default_ttl -->
+        @endif
+
     </div>
     <div class="box-footer">
         <a href="{{ route('zones.index') }}">

--- a/resources/views/zone/_form_master.blade.php
+++ b/resources/views/zone/_form_master.blade.php
@@ -145,11 +145,11 @@
         });
 
         $("#copy_global_settings").click(function () {
-            $("#refresh").val("{{ \Registry::get('zone_default.refresh') }}");
-            $("#retry").val("{{ \Registry::get('zone_default.retry') }}");
-            $("#expire").val("{{ \Registry::get('zone_default.expire') }}");
-            $("#negative_ttl").val("{{ \Registry::get('zone_default.negative_ttl') }}");
-            $("#default_ttl").val("{{ \Registry::get('zone_default.default_ttl') }}");
+            $("#refresh").val("{{ \Registry::get('zone_default_refresh') }}");
+            $("#retry").val("{{ \Registry::get('zone_default_retry') }}");
+            $("#expire").val("{{ \Registry::get('zone_default_expire') }}");
+            $("#negative_ttl").val("{{ \Registry::get('zone_default_negative_ttl') }}");
+            $("#default_ttl").val("{{ \Registry::get('zone_default_default_ttl') }}");
         });
     });
 </script>

--- a/resources/views/zone/_form_master.blade.php
+++ b/resources/views/zone/_form_master.blade.php
@@ -20,6 +20,106 @@
             </div>
         </div>
         <!-- ./ domain -->
+
+        <!-- custom_settings -->
+        <div class="form-group {{ $errors->has('custom_settings') ? 'has-error' : '' }}">
+            <div class="checkbox">
+                <label class="control-label" data-toggle="collapse" data-target="#custom_settings_section">>
+                    {{ Form::checkbox('custom_settings', true, null, ['id' => 'custom_settings']) }}
+                    {{ trans('zone/model.custom_settings') }}
+                </label>
+            </div>
+        </div>
+        <!-- ./ custom_settings -->
+
+        <!-- custom settings section -->
+        <div class="{{ (isset($zone->custom_settings) && ($zone->custom_settings)) ? 'collapse in' : 'collapse' }}" id="custom_settings_section">
+
+            <h4>{{ trans('zone/title.custom_settings') }}</h4>
+
+            <fieldset id="custom_settings_fields">
+
+                <!-- Copy from global settings -->
+                <div class="form-group">
+                    <button class="btn btn-default" type="button" id="copy_global_settings">Copy values from defaults
+                    </button>
+                </div>
+                <!-- ./ Copy from global settings -->
+
+                <!-- row -->
+                <div class="row">
+                    <div class="col-md-6">
+                        <!-- refresh -->
+                        <div class="form-group {{ $errors->has('refresh') ? 'has-error' : '' }}">
+                            {!! Form::label('refresh', trans('zone/model.refresh'), array('class' => 'control-label required')) !!}
+                            <div class="controls">
+                                {!! Form::number('refresh', null, array('class' => 'form-control', 'required' => 'required')) !!}
+                                <span class="help-block">{{ trans('zone/model.refresh_help') }}</span>
+                                <span class="help-block">{{ $errors->first('refresh', ':message') }}</span>
+                            </div>
+                        </div>
+                        <!-- ./ refresh -->
+                    </div>
+                    <div class="col-md-6">
+
+                        <!-- retry -->
+                        <div class="form-group {{ $errors->has('retry') ? 'has-error' : '' }}">
+                            {!! Form::label('retry', trans('zone/model.retry'), array('class' => 'control-label required')) !!}
+                            <div class="controls">
+                                {!! Form::number('retry', null, array('class' => 'form-control', 'required' => 'required')) !!}
+                                <span class="help-block">{{ trans('zone/model.retry_help') }}</span>
+                                <span class="help-block">{{ $errors->first('retry', ':message') }}</span>
+                            </div>
+                        </div>
+                        <!-- ./ retry -->
+                    </div>
+                </div>
+                <!-- ./ row -->
+
+                <!-- row -->
+                <div class="row">
+                    <div class="col-md-6">
+                        <!-- expire -->
+                        <div class="form-group {{ $errors->has('expire') ? 'has-error' : '' }}">
+                            {!! Form::label('expire', trans('zone/model.expire'), array('class' => 'control-label required')) !!}
+                            <div class="controls">
+                                {!! Form::number('expire', null, array('class' => 'form-control', 'required' => 'required')) !!}
+                                <span class="help-block">{{ trans('zone/model.expire_help') }}</span>
+                                <span class="help-block">{{ $errors->first('expire', ':message') }}</span>
+                            </div>
+                        </div>
+                        <!-- ./ expire -->
+                    </div>
+                    <div class="col-md-6">
+
+                        <!-- negative_ttl -->
+                        <div class="form-group {{ $errors->has('negative_ttl') ? 'has-error' : '' }}">
+                            {!! Form::label('negative_ttl', trans('zone/model.negative_ttl'), array('class' => 'control-label required')) !!}
+                            <div class="controls">
+                                {!! Form::number('negative_ttl', null, array('class' => 'form-control', 'required' => 'required')) !!}
+                                <span class="help-block">{{ trans('zone/model.negative_ttl_help') }}</span>
+                                <span class="help-block">{{ $errors->first('negative_ttl', ':message') }}</span>
+                            </div>
+                        </div>
+                        <!-- ./ negative_ttl -->
+                    </div>
+                </div>
+                <!-- ./ row -->
+
+                <!-- default_ttl -->
+                <div class="form-group {{ $errors->has('default_ttl') ? 'has-error' : '' }}">
+                    {!! Form::label('default_ttl', trans('zone/model.default_ttl'), array('class' => 'control-label required')) !!}
+                    <div class="controls">
+                        {!! Form::number('default_ttl', null, array('class' => 'form-control', 'required' => 'required')) !!}
+                        <span class="help-block">{{ trans('zone/model.default_ttl_help') }}</span>
+                        <span class="help-block">{{ $errors->first('default_ttl', ':message') }}</span>
+                    </div>
+                </div>
+                <!-- ./ default_ttl -->
+
+            </fieldset>
+        </div>
+        <!-- ./ custom settings section -->
     </div>
 
     <div class="box-footer">
@@ -34,3 +134,23 @@
     </div>
 </div>
 {!! Form::close() !!}
+
+@push('scripts')
+<script>
+    $(function () {
+        $("#custom_settings_fields").prop("disabled", !$("#custom_settings").prop("checked"));
+
+        $("#custom_settings").change(function () {
+            $("#custom_settings_fields").prop("disabled", !this.checked);
+        });
+
+        $("#copy_global_settings").click(function () {
+            $("#refresh").val("{{ \Registry::get('zone_default.refresh') }}");
+            $("#retry").val("{{ \Registry::get('zone_default.retry') }}");
+            $("#expire").val("{{ \Registry::get('zone_default.expire') }}");
+            $("#negative_ttl").val("{{ \Registry::get('zone_default.negative_ttl') }}");
+            $("#default_ttl").val("{{ \Registry::get('zone_default.default_ttl') }}");
+        });
+    });
+</script>
+@endpush


### PR DESCRIPTION
Add specific custom settings per zone. An user can override global settings for refresh, retry, expire, negative_ttl and default_ttl.