### PR TITLE
Fix bower dependency problems. Solves issue #42

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,5 +20,8 @@
   ],
   "dependencies": {
     "admin-lte": "^2.4.3"
+  },
+  "resolutions": {
+    "jquery": "^3.3.1"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
     "tests"
   ],
   "dependencies": {
-    "AdminLTE": "admin-lte#^2.3.6"
+    "admin-lte": "^2.4.3"
   }
 }


### PR DESCRIPTION
Previous AdminLTE theme version has jQuery 2.0.0 as a dependency, this version is deprecated and could not be resolved properly. I've updated theme to admin-lte latest using jQuery 3.3.1.
Close #42 