### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -2,11 +2,16 @@ FROM php:7.2-fpm
 
 MAINTAINER Paco Orozco <paco@pacoorozco.info>
 
-# Install "libmcrypt-dev, "zlib1g-dev".
+# Install "zlib1g-dev".
 RUN apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
-        libmcrypt-dev \
         zlib1g-dev
+
+# Install mcrypt
+RUN apt-get update -y && \
+apt-get install -y libmcrypt-dev && \
+pecl install mcrypt-1.0.1 && \
+docker-php-ext-enable mcrypt
 
 # Install the PHP needed extentions
 RUN docker-php-ext-install \

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.1-fpm
+FROM php:7.2-fpm
 
 MAINTAINER Paco Orozco <paco@pacoorozco.info>
 
@@ -11,7 +11,6 @@ RUN apt-get update \
 # Install the PHP needed extentions
 RUN docker-php-ext-install \
     mbstring \
-    mcrypt \
     pdo_mysql \
     zip
 


### PR DESCRIPTION
Change from php:7.1-fpm to php:7.2-fpm
mcrypt is deprecated in ph7.2-fpm, but openssl is included, remove mcrypt from docker-compose exec app php artisan migrate

**What issue type does this pull request address?** (keep at least one, remove the others)  
/kind bug

**What is this pull request for? Which issues does it resolve?** (use `resolves #<issue_number>` if possible)  
resolves #60 

**Does this pull request has user-facing changes?** (e.g. config changes, new/modified commands, new/modified flags)  
No

**Does this pull request add new dependencies?**  
No

**What else do we need to know?** 
