### PR TITLE
add missing newline at end of deadlist file

### DIFF
--- a/app/Console/Commands/ProBINDPushZones.php
+++ b/app/Console/Commands/ProBINDPushZones.php
@@ -69,6 +69,9 @@ class ProBINDPushZones extends Command
                 ->pluck('domain')
                 ->all()
         );
+        if ($content !== '') {
+            $content .= "\n";
+        }
         $path = self::CONFIG_BASEDIR . DIRECTORY_SEPARATOR . 'deadlist';
         Storage::put($path, $content, 'private');
 


### PR DESCRIPTION
The deadlist file is created without a newline at the end of the last line. Fix that.