### PR TITLE
Make zone serial increment properly

### DIFF
--- a/app/Http/Controllers/ZoneController.php
+++ b/app/Http/Controllers/ZoneController.php
@@ -88,7 +88,7 @@ class ZoneController extends Controller
         if ($request->input('zone_type') === 'secondary-zone') {
             $zone->master_server = $request->input('master_server');
         } else {
-            $zone->serial = Zone::generateSerialNumber();
+            $zone->getNewSerialNumber();
             $zone->setPendingChanges();
 
             // deal with checkboxes

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,11 +32,11 @@ class AppServiceProvider extends ServiceProvider
         // Touch Zone when save/delete a Record
         Record::saving(function (Record $record) {
             $zone = $record->zone()->first();
-            $zone->setPendingChanges(true);
+            $zone->getNewSerialNumber();
         });
         Record::deleting(function (Record $record) {
             $zone = $record->zone()->first();
-            $zone->setPendingChanges(true);
+            $zone->getNewSerialNumber();
         });
     }
 


### PR DESCRIPTION
Zone serial was resetting (decrementing) when saving zone, and failing to increment when editing/adding/removing a record.